### PR TITLE
Adapt StaticATokenLM interface

### DIFF
--- a/contracts/interfaces/IInitializableStaticATokenLM.sol
+++ b/contracts/interfaces/IInitializableStaticATokenLM.sol
@@ -30,11 +30,13 @@ interface IInitializableStaticATokenLM {
    * @param aToken The address of the underlying aToken (aWETH)
    * @param staticATokenName The name of the Static aToken
    * @param staticATokenSymbol The symbol of the Static aToken
+   * @param l1TokenBridge The address of the bridge to Starknet
    */
   function initialize(
     ILendingPool pool,
     address aToken,
     string calldata staticATokenName,
-    string calldata staticATokenSymbol
+    string calldata staticATokenSymbol,
+    address l1TokenBridge
   ) external;
 }

--- a/contracts/protocol/tokenization/StaticATokenLMOld.sol
+++ b/contracts/protocol/tokenization/StaticATokenLMOld.sol
@@ -91,7 +91,8 @@ contract StaticATokenLMOld is
     ILendingPool pool,
     address aToken,
     string calldata staticATokenName,
-    string calldata staticATokenSymbol
+    string calldata staticATokenSymbol,
+    address l1TokenBridge
   ) external override initializer {
     LENDING_POOL = pool;
     ATOKEN = IERC20(aToken);


### PR DESCRIPTION
I figured out too late that the previous change introduces a compilation error. It works again by adapting the interface.